### PR TITLE
Use selective import

### DIFF
--- a/generator/app.d
+++ b/generator/app.d
@@ -8,12 +8,12 @@ import language.d;
 
 import asdf;
 
-import std.stdio;
-import std.file;
-import std.path;
-import std.format;
-import std.getopt;
-import std.range;
+import std.stdio : writeln, writefln;
+import std.file : exists, readText, mkdirRecurse, isDir, writeFile = write;
+import std.path : buildPath, dirName;
+import std.format : format, string;
+import std.getopt : defaultGetoptPrinter, getopt, GetoptResult;
+import std.range : empty;
 
 void usage(GetoptResult opt)
 {
@@ -71,7 +71,7 @@ void main(string[] args)
 	API gdnativeAPI = gdnativeJson.readText.deserialize!(API);
 	auto cPath = buildPath(outputDir, "classes", "godot", "c", "api.d");
 	if(!cPath.dirName.exists) cPath.dirName.mkdirRecurse;
-	std.file.write(cPath, gdnativeAPI.source);
+	writeFile(cPath, gdnativeAPI.source);
 	
 	ClassList classList;
 	classList.classes = classesJson.readText.deserialize!(GodotClass[]);
@@ -118,7 +118,7 @@ void main(string[] args)
 	+/
 	void checkEnumType(ref string type)
 	{
-		import std.algorithm.searching;
+		import std.algorithm.searching : canFind;
 		if(type.isEnum)
 		{
 			auto split = type.splitEnumName;
@@ -145,7 +145,6 @@ void main(string[] args)
 		// output files for the selected lang
 		foreach(const cof; lang.classOutputFiles)
 		{
-			import std.string;
 			
 			string[2] arr = cof.generator(c);
 			if(!arr[0].empty)
@@ -155,7 +154,7 @@ void main(string[] args)
 				string dir = dirName(p);
 				if(!dir.exists) mkdirRecurse(dir);
 				
-				std.file.write( p, arr[1] );
+				writeFile(p, arr[1]);
 			}
 		}
 	}


### PR DESCRIPTION
Use selective import on the main file to avoid clashing (std.stdio.write and std.file.write).
I also removed `import std.string;` as it would compile without issues.

Side note:
I don't like the idea that the absence of a needed file returns an exception. It could just do `return 1;` and avoid unnecessary out put like:
`object.Exception@generator/app.d(50): Class API file api.json doesn't exist`
`----------------`
`??:? _Dmain [0xa4fa2ae2]`
I can change it for you if you're okay with it.. :)