### PR TITLE
Change shebang

### DIFF
--- a/linux-gen.sh
+++ b/linux-gen.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 #Godot path
 GODOT="godot"


### PR DESCRIPTION
Not all distros put bash in /usr/bin/bash, Ubuntu doesn't.
This shouldn't affect Arch or Arch based distros.